### PR TITLE
Reverted changes to autocomplete as I realized I messed up

### DIFF
--- a/src/main/kotlin/com/a0/kobalt/bots/base/Base.kt
+++ b/src/main/kotlin/com/a0/kobalt/bots/base/Base.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package com.a0.kobalt.bots.base
 
 import com.a0.kobalt.bots.sharded.KShardedBot
@@ -6,21 +8,13 @@ import com.a0.kobalt.commands.CommandGroup
 import com.a0.kobalt.commands.CommandMeta
 import com.a0.kobalt.dispatcher.CommandDispatcher
 import com.a0.kobalt.dispatcher.EventWaiter
-import com.a0.kobalt.exceptions.ButtonActionFailed
-import com.a0.kobalt.exceptions.ButtonActionNotFound
-import com.a0.kobalt.exceptions.ButtonException
-import com.a0.kobalt.exceptions.ButtonExists
-import com.a0.kobalt.exceptions.CommandException
-import com.a0.kobalt.exceptions.CommandFailed
-import com.a0.kobalt.exceptions.CommandNotFound
-import com.a0.kobalt.exceptions.KobaltException
+import com.a0.kobalt.exceptions.*
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import net.dv8tion.jda.api.events.Event
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -83,10 +77,6 @@ abstract class KBase(
         } catch (e: CommandException) {
             this.onInteractionError(event, e)
         }
-    }
-
-    override fun onCommandAutoCompleteInteraction(event: CommandAutoCompleteInteractionEvent) {
-        CommandDispatcher.handleAutocomplete(event)
     }
 
     override fun onButtonInteraction(event: ButtonInteractionEvent) {

--- a/src/main/kotlin/com/a0/kobalt/bots/sharded/ShardedBot.kt
+++ b/src/main/kotlin/com/a0/kobalt/bots/sharded/ShardedBot.kt
@@ -2,7 +2,6 @@ package com.a0.kobalt.bots.sharded
 
 import com.a0.kobalt.bots.base.KBase
 import com.a0.kobalt.commands.CommandType
-import com.a0.kobalt.commands.NoAutoComplete
 import com.a0.kobalt.dispatcher.CommandDispatcher
 import net.dv8tion.jda.api.audio.AudioModuleConfig
 import net.dv8tion.jda.api.audio.dave.DaveSessionFactory
@@ -166,8 +165,8 @@ open class KShardedBot(
                         val optionData = OptionData(arg.type, arg.name, arg.description, arg.required)
 
                         when {
-                            arg.choices.isNotEmpty() -> arg.choices.forEach { optionData.addChoice(it, it.lowercase()) }
-                            arg.autoComplete != NoAutoComplete -> optionData.setAutoComplete(true)
+                            arg.choices.isNotEmpty() -> arg.choices.forEach { optionData.addChoice(it, it) }
+                            arg.autoComplete -> optionData.setAutoComplete(true)
                         }
                         slashData.addOptions(optionData)
                     }

--- a/src/main/kotlin/com/a0/kobalt/bots/standard/Bot.kt
+++ b/src/main/kotlin/com/a0/kobalt/bots/standard/Bot.kt
@@ -2,7 +2,6 @@ package com.a0.kobalt.bots.standard
 
 import com.a0.kobalt.bots.base.KBase
 import com.a0.kobalt.commands.CommandType
-import com.a0.kobalt.commands.NoAutoComplete
 import com.a0.kobalt.dispatcher.CommandDispatcher
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
@@ -160,8 +159,8 @@ open class KBot(
                         val optionData = OptionData(arg.type, arg.name, arg.description, arg.required)
 
                         when {
-                            arg.choices.isNotEmpty() -> arg.choices.forEach { optionData.addChoice(it, it.lowercase()) }
-                            arg.autoComplete != NoAutoComplete -> optionData.setAutoComplete(true)
+                            arg.choices.isNotEmpty() -> arg.choices.forEach { optionData.addChoice(it, it) }
+                            arg.autoComplete -> optionData.setAutoComplete(true)
                         }
                         slashData.addOptions(optionData)
                     }

--- a/src/main/kotlin/com/a0/kobalt/commands/Commands.kt
+++ b/src/main/kotlin/com/a0/kobalt/commands/Commands.kt
@@ -2,12 +2,7 @@ package com.a0.kobalt.commands
 
 import com.a0.kobalt.bots.base.KBase
 import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.events.interaction.GenericAutoCompleteInteractionEvent
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
-import org.apache.commons.collections4.iterators.EmptyListIterator
-import kotlin.reflect.KClass
 
 // To inherit from to make sure all commands have access to the bot
 open class CommandGroup(
@@ -80,13 +75,5 @@ annotation class SlashOption(
     val required: Boolean = false,
     val type: OptionType,
     val choices: Array<String> = [],
-    val autoComplete: KClass<out AutoCompleteHandler> = NoAutoComplete::class,
+    val autoComplete: Boolean = false,
 )
-
-interface AutoCompleteHandler {
-    fun handle(event: CommandAutoCompleteInteractionEvent): List<String>
-}
-
-object NoAutoComplete : AutoCompleteHandler {
-    override fun handle(event: CommandAutoCompleteInteractionEvent): List<String> = emptyList()
-}

--- a/src/main/kotlin/com/a0/kobalt/commands/Meta.kt
+++ b/src/main/kotlin/com/a0/kobalt/commands/Meta.kt
@@ -11,7 +11,7 @@ data class SlashOptionDetails(
     val required: Boolean,
     val type: OptionType,
     val choices: Set<String> = emptySet(),
-    val autoComplete: AutoCompleteHandler = NoAutoComplete,
+    val autoComplete: Boolean,
 )
 
 data class CommandMeta(

--- a/src/main/kotlin/com/a0/kobalt/dispatcher/CommandDispatcher.kt
+++ b/src/main/kotlin/com/a0/kobalt/dispatcher/CommandDispatcher.kt
@@ -2,19 +2,7 @@
 
 package com.a0.kobalt.dispatcher
 
-import com.a0.kobalt.commands.Command
-import com.a0.kobalt.commands.CommandGroup
-import com.a0.kobalt.commands.CommandMeta
-import com.a0.kobalt.commands.CommandType
-import com.a0.kobalt.commands.HybridCommand
-import com.a0.kobalt.commands.NoAutoComplete
-import com.a0.kobalt.commands.OnReadyCall
-import com.a0.kobalt.commands.PendingIntervalTask
-import com.a0.kobalt.commands.PendingTimedTask
-import com.a0.kobalt.commands.SlashCommand
-import com.a0.kobalt.commands.SlashOption
-import com.a0.kobalt.commands.SlashOptionDetails
-import com.a0.kobalt.commands.Task
+import com.a0.kobalt.commands.*
 import com.a0.kobalt.exceptions.ButtonActionFailed
 import com.a0.kobalt.exceptions.ButtonActionNotFound
 import com.a0.kobalt.exceptions.CommandFailed
@@ -23,7 +11,6 @@ import com.a0.kobalt.ui.buttons.KButtonRegistry
 import io.github.oshai.kotlinlogging.KLogger
 import kotlinx.coroutines.*
 import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -48,7 +35,6 @@ internal object CommandDispatcher {
     // maps
     private val aliasMap = mutableMapOf<String, CommandMeta>()
     private val slashCommandsMap = mutableMapOf<String, CommandMeta>()
-    private val autoCompleteOptionsMap = mutableMapOf<String, Map<String, SlashOptionDetails>>()
 
     // interval task things
     private val pendingIntervalTasksList = mutableListOf<PendingIntervalTask>()
@@ -281,7 +267,6 @@ internal object CommandDispatcher {
             )
         commands.add(commandMeta)
         slashCommandsMap[commandMeta.name.lowercase()] = commandMeta
-        registerAutoCompleteOptions(commandMeta)
         logger.debug { "Registered slash command: ${annotation.name}" }
     }
 
@@ -312,7 +297,6 @@ internal object CommandDispatcher {
         commands.add(commandMeta)
         slashCommandsMap[commandMeta.name.lowercase()] = commandMeta
         registerAliases(commandMeta)
-        registerAutoCompleteOptions(commandMeta)
         logger.debug { "Registered hybrid command: ${annotation.name}" }
     }
 
@@ -326,10 +310,7 @@ internal object CommandDispatcher {
                     required = option.required,
                     type = option.type,
                     choices = option.choices.toSet(),
-                    autoComplete =
-                        option.autoComplete.objectInstance ?: option.autoComplete.java
-                            .getDeclaredConstructor()
-                            .newInstance(),
+                    autoComplete = option.autoComplete,
                 )
             }.toList()
 
@@ -337,16 +318,6 @@ internal object CommandDispatcher {
         aliasMap["$prefix${commandMeta.name}".lowercase()] = commandMeta
         commandMeta.aliases.forEach { alias ->
             aliasMap["$prefix$alias".lowercase()] = commandMeta
-        }
-    }
-
-    private fun registerAutoCompleteOptions(commandMeta: CommandMeta) {
-        val optionsMap =
-            commandMeta.args
-                .filter { it.autoComplete != NoAutoComplete }
-                .associateBy { it.name.lowercase() }
-        if (optionsMap.isNotEmpty()) {
-            autoCompleteOptionsMap[commandMeta.name.lowercase()] = optionsMap
         }
     }
 
@@ -457,22 +428,6 @@ internal object CommandDispatcher {
                 commandGroupName = command.instance.javaClass.name,
                 cause = e.cause ?: e,
             )
-        }
-    }
-
-    internal fun handleAutocomplete(event: CommandAutoCompleteInteractionEvent) {
-        val option =
-            autoCompleteOptionsMap[event.name]?.get(event.focusedOption.name) ?: run {
-                event.replyChoices().queue()
-                return
-            }
-
-        val results = option.autoComplete.handle(event)
-
-        if (results.isEmpty()) {
-            event.replyChoices().queue()
-        } else {
-            event.replyChoiceStrings(results).queue()
         }
     }
 

--- a/src/main/kotlin/com/a0/kobalt/ui/buttons/KButtonRegistry.kt
+++ b/src/main/kotlin/com/a0/kobalt/ui/buttons/KButtonRegistry.kt
@@ -1,11 +1,9 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package com.a0.kobalt.ui.buttons
 
 import com.a0.kobalt.exceptions.ButtonExists
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
 
 object KButtonRegistry {


### PR DESCRIPTION
Realized I added too much complexity for something so simple so the changes have been reverted.
the way autocomplete works now:
* Mark a slash option as autocomplete in the slash option annotation
* Override onCommandAutoCompleteInteraction in your subclass of KBot or KShardedBot to address it